### PR TITLE
return the run url as well

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+node_modules/

--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ The ID of the newly created run. Notice that for preview deployments, no run is 
 
 ### `run-url`
 
-The fully qualified URL of the newly created run (e.g. `https://app.qawolf.com/runs/<run-id>`). Notice that for preview deployments, no run is automatically initiated and therefore no `run-id` will be available.
+The fully qualified URL of the newly created run (e.g. `https://app.qawolf.com/runs/<run-id>`). Notice that for preview deployments, no run is automatically initiated and therefore no `run-url` will be available.
 
 ## Usage
 

--- a/README.md
+++ b/README.md
@@ -59,6 +59,10 @@ A pull request number associated with the deployment, if applicable.
 
 The ID of the newly created run. Notice that for preview deployments, no run is automatically initiated and therefore no `run-id` will be available.
 
+### `environment-id`
+
+The environment ID the newly created run is running against. Notice that for preview deployments, no run is automatically initiated and therefore no `environment-id` will be available.
+
 ### `run-url`
 
 The fully qualified URL of the newly created run (e.g. `https://app.qawolf.com/runs/<run-id>`). Notice that for preview deployments, no run is automatically initiated and therefore no `run-url` will be available.

--- a/README.md
+++ b/README.md
@@ -59,6 +59,10 @@ A pull request number associated with the deployment, if applicable.
 
 The ID of the newly created run. Notice that for preview deployments, no run is automatically initiated and therefore no `run-id` will be available.
 
+### `run-url`
+
+The fully qualified URL of the newly created run (e.g. `https://app.qawolf.com/runs/<run-id>`). Notice that for preview deployments, no run is automatically initiated and therefore no `run-id` will be available.
+
 ## Usage
 
 > ⚠️ The following parameters given in the `with` clause may vary depending on your setup.

--- a/action.yml
+++ b/action.yml
@@ -41,6 +41,10 @@ inputs:
 outputs:
   run-id:
     description: "The run ID corresponding to the newly created run. It can be used with ci-greenlight integration."
+  environment-id:
+    description: "The environment ID extracted from the run trigger."
+  run-url:
+    description: "The URL to the triggered test suite run in QAWolf"
 runs:
   using: "node24"
   main: "dist/index.js"

--- a/src/index.ts
+++ b/src/index.ts
@@ -52,7 +52,7 @@ async function runGitHubAction() {
   const { environmentId, runId } = deployResult;
   core.setOutput("environment-id", environmentId);
   core.setOutput("run-id", runId);
-  const runUrl = runId ? new URL(`/runs/${runId}`, qawolfBaseUrl).href : undefined);
+  const runUrl = runId ? new URL(`/runs/${runId}`, qawolfBaseUrl).href : undefined;
   core.setOutput("run-url", runUrl);
 }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -52,7 +52,8 @@ async function runGitHubAction() {
   const { environmentId, runId } = deployResult;
   core.setOutput("environment-id", environmentId);
   core.setOutput("run-id", runId);
-  core.setOutput("run-url", `https://app.qawolf.com/runs/${runId}`);
+  const runUrl = runId ? new URL(`/runs/${runId}`, qawolfBaseUrl).href : undefined);
+  core.setOutput("run-url", runUrl);
 }
 
 runGitHubAction().catch((error) => {

--- a/src/index.ts
+++ b/src/index.ts
@@ -52,6 +52,7 @@ async function runGitHubAction() {
   const { environmentId, runId } = deployResult;
   core.setOutput("environment-id", environmentId);
   core.setOutput("run-id", runId);
+  core.setOutput("run-url", `https://app.qawolf.com/runs/${runId}`);
 }
 
 runGitHubAction().catch((error) => {

--- a/src/index.ts
+++ b/src/index.ts
@@ -49,6 +49,7 @@ async function runGitHubAction() {
     );
     return;
   }
+
   const { environmentId, runId } = deployResult;
   core.setOutput("environment-id", environmentId);
   core.setOutput("run-id", runId);

--- a/src/validateInput.ts
+++ b/src/validateInput.ts
@@ -60,11 +60,6 @@ export function validateInput(
       required: false,
     }) || relevantEventData?.pullRequestNumber;
 
-  const waitOnResults =
-    core.getInput("wait-on-results", {
-      required: false
-    });
-
   if (!shaInput && !branchInput && !deploymentTypeInput) {
     return {
       error:

--- a/src/validateInput.ts
+++ b/src/validateInput.ts
@@ -130,7 +130,6 @@ export function validateInput(
       },
       sha: shaInput,
       variables: validatedEnvironmentVariables,
-      waitOnResults: waitOnResults,
     },
     isValid: true,
     ...(ephemeralEnvironmentInput === "true"

--- a/src/validateInput.ts
+++ b/src/validateInput.ts
@@ -60,6 +60,11 @@ export function validateInput(
       required: false,
     }) || relevantEventData?.pullRequestNumber;
 
+  const waitOnResults =
+    core.getInput("wait-on-results", {
+      required: false
+    });
+
   if (!shaInput && !branchInput && !deploymentTypeInput) {
     return {
       error:
@@ -130,6 +135,7 @@ export function validateInput(
       },
       sha: shaInput,
       variables: validatedEnvironmentVariables,
+      waitOnResults: waitOnResults,
     },
     isValid: true,
     ...(ephemeralEnvironmentInput === "true"


### PR DESCRIPTION
This is a simple change, but users may appreciate just having the run URL rather than having to build it themselves. And if the URL format changes, this output makes it a touch simpler to consistently produce.