### PR TITLE
Add ability to wait on test results

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+node_modules/

--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ The ID of the newly created run. Notice that for preview deployments, no run is 
 
 ### `run-url`
 
-The fully qualified URL of the newly created run (e.g. `https://app.qawolf.com/runs/<run-id>`). Notice that for preview deployments, no run is automatically initiated and therefore no `run-id` will be available.
+The fully qualified URL of the newly created run (e.g. `https://app.qawolf.com/runs/<run-id>`). Notice that for preview deployments, no run is automatically initiated and therefore no `run-url` will be available.
 
 ## Usage
 

--- a/README.md
+++ b/README.md
@@ -59,6 +59,10 @@ A pull request number associated with the deployment, if applicable.
 
 The ID of the newly created run. Notice that for preview deployments, no run is automatically initiated and therefore no `run-id` will be available.
 
+### `environment-id`
+
+The environment ID the newly created run is running against. Notice that for preview deployments, no run is automatically initiated and therefore no `environment-id` will be available.
+
 ### `run-url`
 
 The fully qualified URL of the newly created run (e.g. `https://app.qawolf.com/runs/<run-id>`). Notice that for preview deployments, no run is automatically initiated and therefore no `run-url` will be available.

--- a/README.md
+++ b/README.md
@@ -59,6 +59,10 @@ A pull request number associated with the deployment, if applicable.
 
 The ID of the newly created run. Notice that for preview deployments, no run is automatically initiated and therefore no `run-id` will be available.
 
+### `run-url`
+
+The fully qualified URL of the newly created run (e.g. `https://app.qawolf.com/runs/<run-id>`). Notice that for preview deployments, no run is automatically initiated and therefore no `run-id` will be available.
+
 ## Usage
 
 > ⚠️ The following parameters given in the `with` clause may vary depending on your setup.

--- a/README.md
+++ b/README.md
@@ -33,6 +33,10 @@ JSON-formatted environment variables for the deployment to be tested.
 
 Whether the deployment is an ephemeral environment
 
+### `wait-on-results`
+
+Whether to poll for test suite completion before completing the job
+
 ## Auto-Extracted Inputs (Optional)
 
 The following inputs are automatically extracted from the GitHub event context. They only need to be specified if you want to override the default values.

--- a/action.yml
+++ b/action.yml
@@ -41,6 +41,10 @@ inputs:
 outputs:
   run-id:
     description: "The run ID corresponding to the newly created run. It can be used with ci-greenlight integration."
+  environment-id:
+    description: "The environment ID extracted from the run trigger."
+  run-url:
+    description: "The URL to the triggered test suite run in QAWolf"
 runs:
   using: "node24"
   main: "dist/index.js"

--- a/action.yml
+++ b/action.yml
@@ -38,6 +38,10 @@ inputs:
     required: false
     description: >
       The base URL of the QA Wolf API.
+  wait-on-results:
+    required: false
+    description: "Whether to actually poll on the results of the test suite before completing"
+
 outputs:
   run-id:
     description: "The run ID corresponding to the newly created run. It can be used with ci-greenlight integration."

--- a/src/index.ts
+++ b/src/index.ts
@@ -20,7 +20,7 @@ async function runGitHubAction() {
     return;
   }
   const { apiKey, deployConfig, qawolfBaseUrl } = validationResult;
-  const { attemptNotifyDeploy } = makeQaWolfSdk(
+  const { attemptNotifyDeploy, pollCiGreenlightStatus } = makeQaWolfSdk(
     {
       apiKey,
       serviceBase: qawolfBaseUrl,
@@ -50,11 +50,21 @@ async function runGitHubAction() {
     return;
   }
 
-  const { environmentId, runId } = deployResult;
+  const { environmentId, runId, waitOnResults } = deployResult;
   core.setOutput("environment-id", environmentId);
   core.setOutput("run-id", runId);
   const runUrl = runId ? new URL(`/runs/${runId}`, qawolfBaseUrl).href : undefined;
   core.setOutput("run-url", runUrl);
+
+  if (runId && waitOnResults) {
+    const { outcome } = await pollCiGreenlightStatus({
+      runId,
+    });
+    if (outcome !== 'success') {
+      core.setFailed(`Test Suite failed: ${outcome}`);
+    }
+    core.info(`Run Details: ${runUrl}`);
+  }
 }
 
 runGitHubAction().catch((error) => {

--- a/src/index.ts
+++ b/src/index.ts
@@ -52,7 +52,7 @@ async function runGitHubAction() {
   const { environmentId, runId } = deployResult;
   core.setOutput("environment-id", environmentId);
   core.setOutput("run-id", runId);
-  const runUrl = runId ? new URL(`/runs/${runId}`, qawolfBaseUrl).href : undefined);
+  const runUrl = runId ? new URL(`/runs/${runId}`, qawolfBaseUrl).href : undefined;
   core.setOutput("run-url", runUrl);
 }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -52,7 +52,8 @@ async function runGitHubAction() {
   const { environmentId, runId } = deployResult;
   core.setOutput("environment-id", environmentId);
   core.setOutput("run-id", runId);
-  core.setOutput("run-url", `https://app.qawolf.com/runs/${runId}`);
+  const runUrl = runId ? new URL(`/runs/${runId}`, qawolfBaseUrl).href : undefined);
+  core.setOutput("run-url", runUrl);
 }
 
 runGitHubAction().catch((error) => {

--- a/src/index.ts
+++ b/src/index.ts
@@ -52,6 +52,7 @@ async function runGitHubAction() {
   const { environmentId, runId } = deployResult;
   core.setOutput("environment-id", environmentId);
   core.setOutput("run-id", runId);
+  core.setOutput("run-url", `https://app.qawolf.com/runs/${runId}`);
 }
 
 runGitHubAction().catch((error) => {

--- a/src/index.ts
+++ b/src/index.ts
@@ -49,6 +49,7 @@ async function runGitHubAction() {
     );
     return;
   }
+
   const { environmentId, runId } = deployResult;
   core.setOutput("environment-id", environmentId);
   core.setOutput("run-id", runId);

--- a/src/index.ts
+++ b/src/index.ts
@@ -50,13 +50,13 @@ async function runGitHubAction() {
     return;
   }
 
-  const { environmentId, runId, waitOnResults } = deployResult;
+  const { environmentId, runId } = deployResult;
   core.setOutput("environment-id", environmentId);
   core.setOutput("run-id", runId);
   const runUrl = runId ? new URL(`/runs/${runId}`, qawolfBaseUrl).href : undefined;
   core.setOutput("run-url", runUrl);
 
-  if (runId && waitOnResults) {
+  if (runId && deployConfig.waitOnResults) {
     const { outcome } = await pollCiGreenlightStatus({
       runId,
     });

--- a/src/validateInput.ts
+++ b/src/validateInput.ts
@@ -60,11 +60,6 @@ export function validateInput(
       required: false,
     }) || relevantEventData?.pullRequestNumber;
 
-  const waitOnResults =
-    core.getInput("wait-on-results", {
-      required: false
-    });
-
   if (!shaInput && !branchInput && !deploymentTypeInput) {
     return {
       error:

--- a/src/validateInput.ts
+++ b/src/validateInput.ts
@@ -130,7 +130,6 @@ export function validateInput(
       },
       sha: shaInput,
       variables: validatedEnvironmentVariables,
-      waitOnResults: waitOnResults,
     },
     isValid: true,
     ...(ephemeralEnvironmentInput === "true"

--- a/src/validateInput.ts
+++ b/src/validateInput.ts
@@ -60,6 +60,11 @@ export function validateInput(
       required: false,
     }) || relevantEventData?.pullRequestNumber;
 
+  const waitOnResults =
+    core.getInput("wait-on-results", {
+      required: false
+    });
+
   if (!shaInput && !branchInput && !deploymentTypeInput) {
     return {
       error:
@@ -130,6 +135,7 @@ export function validateInput(
       },
       sha: shaInput,
       variables: validatedEnvironmentVariables,
+      waitOnResults: waitOnResults,
     },
     isValid: true,
     ...(ephemeralEnvironmentInput === "true"

--- a/src/validateInput.ts
+++ b/src/validateInput.ts
@@ -59,6 +59,10 @@ export function validateInput(
     core.getInput("pull-request-number", {
       required: false,
     }) || relevantEventData?.pullRequestNumber;
+  const waitOnResults =
+    core.getInput("wait-on-results", {
+      required: false
+    });
 
   if (!shaInput && !branchInput && !deploymentTypeInput) {
     return {
@@ -130,6 +134,7 @@ export function validateInput(
       },
       sha: shaInput,
       variables: validatedEnvironmentVariables,
+      waitOnResults: waitOnResults,
     },
     isValid: true,
     ...(ephemeralEnvironmentInput === "true"


### PR DESCRIPTION
Rather than needing to write additional steps into my GHA workflow, I'd like to have test suites monitored. This PR _should_ do that correctly.

depends on https://github.com/qawolf/notify-qawolf-on-deploy-action/pull/4